### PR TITLE
Update Router.php

### DIFF
--- a/classes/PHPixie/Router.php
+++ b/classes/PHPixie/Router.php
@@ -18,7 +18,12 @@ class Router {
 	 * @var array
 	 */
 	protected $routes = array();
-	
+
+	/**
+	 * Container for route's rule to process in callback function
+	 */
+	protected $tempRule;
+
 	/**
 	 * Constructs a router
 	 *
@@ -90,14 +95,8 @@ class Router {
 			{
 				$pattern = is_array($rule) ? $rule[0] : $rule;
 				$pattern = str_replace(')', ')?', $pattern);
-				$pixie=$this->pixie;
-				$pattern = preg_replace_callback('/<.*?>/', function($str) use ($rule, $pixie) {
-						$str = $str[0];
-						$regexp = '[a-zA-Z0-9\-\._]+';
-						if (is_array($rule))
-							$regexp = $pixie->arr($rule[1], str_replace(array('<', '>'), '', $str), $regexp);
-						return '(?P'.$str.$regexp.')';
-					}, $pattern);
+				$this->tempRule = $rule;
+				$pattern = preg_replace_callback('/<.*?>/', array($this, 'rule'), $pattern);
 
 				preg_match('#^'.$pattern.'/?$#', $uri, $match);
 				if (!empty($match[0]))
@@ -128,5 +127,17 @@ class Router {
 					'params'=>$params
 					);
 	}
-	
+
+	/**
+	 * This method is used only by preg_replace_callback() in method match() instead of making anonymous function
+	 * to avoid fatal memory leak on some server configurations
+	 */
+	protected function rule($str) {
+		$str = $str[0];
+		$regexp = '[a-zA-Z0-9\-\._]+';
+		if(is_array($this->tempRule))
+			$regexp = $this->pixie->arr($this->tempRule[1], str_replace(array('<', '>'), '', $str), $regexp);
+		return '(?P'.$str.$regexp.')';
+	}
+
 }


### PR DESCRIPTION
After upgrading PHP 5.3 to 5.4 this change was the only way to avoid memory leaks caused by preg_replace_callback() creating anonymous functions. I've tested different ways of using function preg_replace_callback() with real and anonymous functions in simple example files on my server and that's the only working result. I didn't find another solution. Tried to increase pcre.backtrack_limit and pcre.recursion_limit but no effect.
